### PR TITLE
Add shared component

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -43,7 +43,7 @@ TIP: For an introduction to Antora and helpful tips for getting started with loc
 
 == Content sources
 
-This repository hosts content for the API docs, the home page, and the site search page. Each of these pages is configured as a separate component in Antora to give each one a unique URL path at the site root.
+This repository hosts content for the API docs, the home page, the site search page, and shared content. Each of these content sources is configured as a separate component in Antora to give each one a unique URL path at the site root.
 
 === API component
 
@@ -69,11 +69,13 @@ Search is powered by an link:{url-algolia}[Algolia] search index. The index is g
 
 image::images/search.png[Preview of site search]
 
-== Global Asciidoc attributes
+== Shared component
 
-The `global-attributes` directory contains attributes that are made available site-wide across all components.
+The `shared/` directory contains content that is intended to be shared across all component versions.
 
-These attributes are merged into the playbook during a build using the {url-extensions}[global attributes extension].
+The attributes in the `ROOT/partials/attributes.yaml` file are merged into the `antora.yml` file of each component version. These are global attributes that are required for all local builds as well as the production build.
+
+The pages in the `terms/partials/` directory are terms that can be referenced in any component version using the {url-extensions}[`glossterm` macro].
 
 == Extensions and macros
 

--- a/README.adoc
+++ b/README.adoc
@@ -20,8 +20,8 @@ endif::[]
 
 toc::[]
 
-[link=https://app.netlify.com/sites/incomparable-treacle-75bd5a/deploys]
-image::https://api.netlify.com/api/v1/badges/478ad2ac-0538-412c-9df2-4e12216e47af/deploy-status[Netlify deploy status]
+[link=https://app.netlify.com/sites/profound-twilight-0b1971/deploys]
+image::https://api.netlify.com/api/v1/badges/b7efcd64-847e-413e-a6a1-78a0845fde35/deploy-status[Netlify deploy status]
 
 This is the Antora playbook project (site build) for the Redpanda docs site published at {url-docs}.
 
@@ -69,13 +69,13 @@ Search is powered by an link:{url-algolia}[Algolia] search index. The index is g
 
 image::images/search.png[Preview of site search]
 
-== Shared component
+=== Shared component
 
 The `shared/` directory contains content that is intended to be shared across all component versions.
 
-The attributes in the `ROOT/partials/attributes.yaml` file are merged into the `antora.yml` file of each component version. These are global attributes that are required for all local builds as well as the production build.
+The attributes in the `ROOT/partials/attributes.yaml` file are merged into the `antora.yml` file of each component version by the {url-extensions}[global attributes extension]. These global attributes are required for all local builds as well as the production build.
 
-The pages in the `terms/partials/` directory are terms that can be referenced in any component version using the {url-extensions}[`glossterm` macro].
+The pages in the `terms/partials/` directory are terms that can be referenced in any component version using the {url-extensions}[`glossterm` macro]. The content of these term page are also added automatically to `reference:glossary.adoc` pages by the {url-extensions}[aggregate terms extension].
 
 == Extensions and macros
 

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -12,7 +12,7 @@ content:
   sources:
   - url: https://github.com/redpanda-data/docs-site
     branches: main
-    start_paths: [site-search, home, api]
+    start_paths: [site-search, home, api, shared]
   - url: https://github.com/redpanda-data/documentation
     branches: [v/*]
 ui:
@@ -34,7 +34,5 @@ antora:
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/unlisted-pages'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/replace-attributes-in-attachments'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/add-global-attributes'
-    org: redpanda-data
-    repo: docs-site
-    branch: main
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/aggregate-terms'
 

--- a/global-attributes/antora-settings.yaml
+++ b/global-attributes/antora-settings.yaml
@@ -1,6 +1,0 @@
-source-highlighter: ~
-tabs-sync-option: true
-idprefix: ''
-idseparator: '-'
-page-pagination: true
-experimental: true

--- a/global-attributes/images.yaml
+++ b/global-attributes/images.yaml
@@ -1,6 +1,0 @@
-    badge-gauge: 'image:https://img.shields.io/badge/Type-Gauge-brightgreen.svg[]'
-    badge-histogram: 'image:https://img.shields.io/badge/Type-Histogram-brightgreen.svg[]'
-    badge-counter: 'image:https://img.shields.io/badge/Type-Counter-brightgreen.svg[]'
-    badge-perf-iops: 'image:https://img.shields.io/badge/Performance-IOPS-yellow.svg[]'
-    badge-perf-storage: 'image:https://img.shields.io/badge/Performance-Storage-yellow.svg[]'
-    badge-deprecated: 'image:https://img.shields.io/badge/-Deprecated-red.svg[]'

--- a/global-attributes/terms.yaml
+++ b/global-attributes/terms.yaml
@@ -1,5 +1,0 @@
-glossary-tooltip: 'data-tippy-content'
-terms:
-- term: tatting
-  definition: test
-  link: https://www.google.com

--- a/global-attributes/versions.yaml
+++ b/global-attributes/versions.yaml
@@ -1,1 +1,0 @@
-latest-console-version: 2.2.2

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -54,4 +54,4 @@ async function serve (done) {
   })
 }
 
-module.exports = { serve, generate, default: series(generate, serve) }
+module.exports = { serve, generate, default: series(generate, serve) } 

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -1,12 +1,12 @@
 site:
   title: Redpanda Docs
   start_page: home:ROOT:index.adoc
-  url: http://localhost:5000
+  url: http://localhost:5002
 content:
   sources:
   - url: .
     branches: HEAD
-    start_paths: [site-search, home, api]
+    start_paths: [site-search, home, api, shared]
   - url: https://github.com/redpanda-data/documentation
     branches: [v/*]
 ui:
@@ -25,6 +25,4 @@ antora:
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/version-fetcher/set-latest-version'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/unlisted-pages'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/add-global-attributes'
-    org: redpanda-data
-    repo: docs-site
-    branch: main
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/aggregate-terms'

--- a/meta-docs/CONTRIBUTING.adoc
+++ b/meta-docs/CONTRIBUTING.adoc
@@ -256,7 +256,6 @@ All content repositories are organized according to the same content hierarchy.
   📁 packages <12>
 ----
 
-
 <1> (Required) The repository root and the content source root. Antora assumes the content source root is at the root of a repository unless the `start_path` or `start_paths` key is assigned a value on a content source in the site’s playbook.
 <2> (Required) A component version descriptor file, named `antora.yml`, is required at each content source root. An `antora.yml` file indicates to Antora that the contents of a directory named `modules/` should be collected and processed.
 <3> (Required) A `modules/` directory must be located at the same hierarchical level as an `antora.yml` file in a content source root.

--- a/meta-docs/STYLE-GUIDE.adoc
+++ b/meta-docs/STYLE-GUIDE.adoc
@@ -548,60 +548,65 @@ image::../images/context-switcher.png[]
 
 Defining glossary terms in documentation ensures clear and consistent communication by facilitating a common understanding among team members and users.
 
-Glossary terms in Redpanda documentation are rendered as links with a tooltip that displays the definition on hover.
+Glossary terms in Redpanda documentation are rendered with a tooltip that displays the definition on hover. Terms also include links to their full definition in the glossary page if one exists.
 
 image::../images/term.png[,100]
 
-To include glossary terms in Redpanda documentation, use the `glossterm` macro:
+To include glossary terms in Redpanda documentation:
+
+. Make sure that the term is defined in a file in the {url-site}/shared/modules/terms[`terms` module] of the `shared` component.
+. If the term is not yet defined, submit a pull request to add a file for your term.
+. Use the `glossterm` macro:
+
+[,asciidoc]
+----
+This is an important glossterm:<term-name>:[]
+----
+
+Replace `<term-name>` with the term.
+
+To facilitate reusing definitions across different pages of the docs, terms are defined in a centralized location in the {url-site}/shared/modules/terms/partials[`modules/terms/partials/`] directory of the `shared` component. At build time, the {url-extensions}[`aggregate-terms` extension] makes the `term-name` and `hover-text` attributes available to the `glossterm` macro. It also looks for a `reference:glossary.adoc` file in each component version and if it exists adds all the term file contents to it.
+
+For local development, you can define terms and their definitions inline:
 
 [,asciidoc]
 ----
 This is an important glossterm:<term-name>:[<definition>]
 ----
 
-Replace `<term-name>` with the term. Replace `<definition>` with the definition of the term.
+Or, in the `local-terms` attribute of the `antora.yml` file:
 
-To facilitate reusing definitions across different pages of the docs, you can define terms and definitions in the `terms.yaml` file of the `global-attributes/` directory in the {url-site} repository or in the `antora.yml` file of a component. If terms are defined in either of these places, you can omit the description, and the macro will take care of inserting it during the build.
-
-.`global-attributes/terms.yaml`
 [,yaml]
 ----
-terms:
-- term: tatting
-  definition: test
-  link: https://www.google.com
-----
-
-.`antora.yml`
-[,yaml]
-----
+name: <some-component>
+version: <version>
 asciidoc:
   attributes:
     local-terms:
-    - term: tatting2
-      definition: test2
-      link: https://www.google.com
-    - term: tatting
-      definition: test3
-      link: https://www.google.com
+    - term: <term-name>
+      definition: <definition>
+      link: <URL> # Optional - adds an external link to the term. Useful for defining links to more detailed definitions on external sites.
 ----
 
-NOTE: If you want terms to link to external URLs, you must define them in one of these files and include the `link` property.
+[,asciidoc]
+----
+This is an important glossterm:<term-name>:[]
+----
 
-IMPORTANT: Any terms defined in the `terms` attribute override those in the `local-terms` attribute.
+IMPORTANT: Links to the glossary page are provided only when terms are defined in the `modules/terms/partials/` directory of the `shared` component.
 
 === Glossary pages
 
-To produce a glossary page with all terms that have been defined in the documentation, create an empty page called `z-glossary.adoc` and include the `glossary` macro:
+To produce a glossary page with all terms that have been defined in the `shared` component, create an empty page called `glossary.adoc` in the `reference` module and include a title:
 
 [,asciidoc]
 ----
 = Glossary
-
-glossary::[]
 ----
 
-During the build, the macro collects all the terms used in `glossterm` macros, sorts them alphabetically, and adds them to the page that includes the `glossary` macro. Any terms without a `link` property link to the glossary page.
+During the build, an extension collects all the terms in the `modules/terms/partials/` directory of the `shared` component, sorts them alphabetically by the file name, and adds them to the page.
+
+IMPORTANT: Make sure to add the glossary page to the nav tree.
 
 == Link macros
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@asciidoctor/tabs": "^1.0.0-beta.5",
         "@octokit/plugin-retry": "^4.1.3",
         "@octokit/rest": "^19.0.7",
-        "@redpanda-data/docs-extensions-and-macros": "^2.5.0",
+        "@redpanda-data/docs-extensions-and-macros": "^3.0.0",
         "algoliasearch": "^4.17.0"
       },
       "devDependencies": {
@@ -704,9 +704,9 @@
       }
     },
     "node_modules/@redpanda-data/docs-extensions-and-macros": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-2.5.1.tgz",
-      "integrity": "sha512-0guzLltLBJy9icoIGARL/x9RNEwl5zSRsD/kJSPYgAVU9WtnPK9JaQfEypCXtrc6hCbLUcaN+FYLFH1IPfNKKA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-3.0.0.tgz",
+      "integrity": "sha512-BDdg5SGYfz7ivPmh9qKQ3AKd4KPBtSmWBB+T7xhzXx8VSXkY66owbURQAPFbZcbi1BZ+Cyb/TA7D2IHkOtf3Qg==",
       "dependencies": {
         "@antora/site-generator": "3.1.2",
         "@octokit/plugin-retry": "^4.1.3",
@@ -717,6 +717,7 @@
         "gulp-connect": "^5.7.0",
         "html-entities": "2.3",
         "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
         "node-html-parser": "5.4.2-0"
       }
     },
@@ -4826,8 +4827,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.assignwith": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@asciidoctor/tabs": "^1.0.0-beta.5",
     "@octokit/plugin-retry": "^4.1.3",
     "@octokit/rest": "^19.0.7",
-    "@redpanda-data/docs-extensions-and-macros": "^2.5.0",
+    "@redpanda-data/docs-extensions-and-macros": "^3.0.0",
     "algoliasearch": "^4.17.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The Antora playbook project for Redpanda documentation.",
   "license": "ISC",
   "scripts": {
-    "build": "antora --to-dir docs --fetch antora-playbook.yml",
+    "build": "if [ \"$PREVIEW\" = \"true\" ]; then antora --to-dir docs --fetch preview-antora-playbook.yml; else antora --to-dir docs --fetch antora-playbook.yml; fi",
     "start": "cross-env-shell LIVERELOAD=true npx gulp",
     "serve": "wds --node-resolve --open home/index.html --watch --root-dir docs"
   },

--- a/preview-antora-playbook.yml
+++ b/preview-antora-playbook.yml
@@ -10,11 +10,9 @@ urls:
   latest_version_segment_strategy: redirect:to
 content:
   sources:
-  - url: https://github.com/redpanda-data/docs-site
-    branches: main
+  - url: .
+    branches: HEAD
     start_paths: [site-search, home, api, shared]
-  - url: https://github.com/redpanda-data/documentation
-    branches: [v/*]
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip

--- a/shared/antora.yml
+++ b/shared/antora.yml
@@ -1,0 +1,6 @@
+name: shared
+version: ~
+asciidoc:
+  attributes:
+    page-hide-view-latest: true
+    page-exclude-from-dropdown-selector: true

--- a/shared/modules/ROOT/partials/attributes.yml
+++ b/shared/modules/ROOT/partials/attributes.yml
@@ -1,0 +1,20 @@
+# Disable default hightlight.js so we can use Prism.js
+source-highlighter: ~
+# Sync tab groups
+tabs-sync-option: true
+idprefix: ''
+idseparator: '-'
+# Next and previous links
+page-pagination: true
+# kbd macro
+experimental: true
+# Create tooltips for glossterm definitions
+glossary-tooltip: 'data-tippy-content'
+# Fallback version for Redpanda Console
+latest-console-version: 2.2.2
+badge-gauge: 'image:https://img.shields.io/badge/Type-Gauge-brightgreen.svg[]'
+badge-histogram: 'image:https://img.shields.io/badge/Type-Histogram-brightgreen.svg[]'
+badge-counter: 'image:https://img.shields.io/badge/Type-Counter-brightgreen.svg[]'
+badge-perf-iops: 'image:https://img.shields.io/badge/Performance-IOPS-yellow.svg[]'
+badge-perf-storage: 'image:https://img.shields.io/badge/Performance-Storage-yellow.svg[]'
+badge-deprecated: 'image:https://img.shields.io/badge/-Deprecated-red.svg[]'

--- a/shared/modules/terms/partials/test.adoc
+++ b/shared/modules/terms/partials/test.adoc
@@ -1,0 +1,11 @@
+== Test
+:term-name: test term
+:hover-text: This is hover text for {term-name}.
+
+{hover-text}
+
+More content here
+
+=== Some heading
+
+image::home::quickstart.png[]


### PR DESCRIPTION
Added global attributes and terms to a `shared` component so that we can read them without requiring a GitHub token.

Depends on https://github.com/redpanda-data/docs-extensions-and-macros/pull/1