### PR TITLE
Run lighthouse on local file

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,8 +4,11 @@ NODE_VERSION = "16"
 [[plugins]]
   package = "@netlify/plugin-lighthouse"
 
+  [plugins.inputs]
+    fail_deploy_on_score_thresholds = "true"
+
   [[plugins.inputs.audits]]
-    path = "home/index.html"
+    path = "current/home/index.html"
 
   [plugins.inputs.settings]
     preset = "desktop"


### PR DESCRIPTION
The updated version of the Netlify Lighthouse plugin now runs on the deploy permalink. Deploy permalinks always serve a `noindex` header, and this means we always see a lower SEO score than expected (since the production URL would not be serving this header). See https://github.com/netlify/netlify-plugin-lighthouse/issues/593

<img width="828" alt="2023-08-12_06-12-36" src="https://github.com/redpanda-data/docs-site/assets/45230295/ee81f391-457a-4196-8711-ba93e0b00701">

As a workaround, this PR reverts the behavior so that the plugin runs on a local file.