### PR TITLE
Remove deprecated branches

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -20,7 +20,7 @@ output:
 content:
   sources:
   - url: https://github.com/redpanda-data/docs
-    branches: [main, v/*, api, shared, 'site-search',v-WIP/*]
+    branches: [main, v/*, api, shared, 'site-search',v-WIP/*,'!v-deprecated/*']
 ui:
   bundle:
     url: https://github.com/redpanda-data/docs-ui/releases/latest/download/ui-bundle.zip


### PR DESCRIPTION
Resolves https://github.com/redpanda-data/documentation-private/issues/2118

Idea is to move the deprecated branches under the prefix `v-deprecated/{version}` for better git hygiene. 

This change is just a formality to exclude the deprecated branches in the playbook. 