### PR TITLE
adds redirects to schema reg in beta

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -120,4 +120,4 @@ status = 301
 [[redirects]]
 from = "/current/manage/schema-reg/*"
 to = "/beta/manage/schema-reg/:splat:"
-status = 301
+status = 307

--- a/netlify.toml
+++ b/netlify.toml
@@ -115,3 +115,9 @@ status = 301
 from = "/docs/*"
 to = "/current/:splat"
 status = 301
+
+
+[[redirects]]
+from = "/current/manage/schema-reg/*"
+to = "/beta/manage/schema-reg/:splat:"
+status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -119,5 +119,5 @@ status = 301
 
 [[redirects]]
 from = "/current/manage/schema-reg/*"
-to = "/beta/manage/schema-reg/:splat:"
+to = "/beta/manage/schema-reg/:splat"
 status = 307


### PR DESCRIPTION
With the removal of schema registry from the current version to beta, we're seeing an increasing number of 404s to those resources. This PR addresses the directs for that. 

Should be removed after GA