### PR TITLE
Add unix timestamp to blog and YT records

### DIFF
--- a/scripts/index-api/index-api.js
+++ b/scripts/index-api/index-api.js
@@ -15,6 +15,7 @@ if (!ALGOLIA_APP_ID || !ALGOLIA_ADMIN_API_KEY || !ALGOLIA_INDEX_NAME) {
 
 const client = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_ADMIN_API_KEY);
 const index = client.initIndex(ALGOLIA_INDEX_NAME);
+const unixTimestamp = Math.floor(Date.now() / 1000)
 
 async function fetchSitemapUrls(sitemapUrl) {
   try {
@@ -62,6 +63,7 @@ async function indexUrlsInAlgolia(urls) {
         title: data.h1,
         titles: data.titles,
         intro: data.intro,
+        unixTimestamp: unixTimestamp,
         type: 'Doc',
         _tags: ['docs','apis']
       };

--- a/scripts/index-blogs/index-blogs.js
+++ b/scripts/index-blogs/index-blogs.js
@@ -81,6 +81,8 @@ async function indexUrlsInAlgolia(urls) {
         return null;
       }
       const { pathname } = new URL(url);
+      // To sort by date, Algolia requires Unix timestamps
+      const unixTimestamp = data.date ? convertToUnixTimestamp(data.date) : '';
       return {
         objectID: `${BASE_URL}${pathname}`,
         title: data.h1,
@@ -89,6 +91,7 @@ async function indexUrlsInAlgolia(urls) {
         category: data.category,
         image: data.imageUrl,
         date: data.date,
+        unixTimestamp: unixTimestamp,
         author: data.author,
         type: 'Blog',
         _tags: ['blogs']
@@ -158,6 +161,20 @@ async function indexUrlsInAlgolia(urls) {
   }).catch(error => {
     console.error(`Error uploading records to Algolia: ${error.message}`);
   });
+}
+
+function convertToUnixTimestamp(dateString) {
+  try {
+      const date = new Date(dateString);
+      if (isNaN(date.getTime())) {
+        console.log(`Invalid date in blog: ${dateString}`);
+        return '';
+      }
+      return Math.floor(date.getTime() / 1000);
+  } catch (error) {
+      console.error(error.message);
+      return '';
+  }
 }
 
 async function generateAlgoliaIndex(sitemapUrl) {

--- a/scripts/index-youtube/index-youtube.js
+++ b/scripts/index-youtube/index-youtube.js
@@ -30,7 +30,7 @@ async function fetchYouTubeVideos() {
           title: video.snippet.title,
           intro: video.snippet.description,
           date: video.snippet.publishedAt,
-          unixTimestamp,
+          unixTimestamp: unixTimestamp,
           image: video.snippet.thumbnails.high.url,
           type: 'Video',
           _tags: ['videos']

--- a/scripts/index-youtube/index-youtube.js
+++ b/scripts/index-youtube/index-youtube.js
@@ -21,13 +21,16 @@ async function fetchYouTubeVideos() {
     try {
       const response = await axios.get(API_URL);
       const videos = response.data.items;
+      // To sort by date, Algolia requires Unix timestamps
+      const unixTimestamp = convertToUnixTimestamp(video.snippet.publishedAt);
       return videos
         .filter(video => video.id && video.id.videoId)
         .map(video => ({
           objectID: `https://www.youtube.com/watch?v=${video.id.videoId}`,
           title: video.snippet.title,
           intro: video.snippet.description,
-          publishedAt: video.snippet.publishedAt,
+          date: video.snippet.publishedAt,
+          unixTimestamp,
           image: video.snippet.thumbnails.high.url,
           type: 'Video',
           _tags: ['videos']
@@ -36,6 +39,20 @@ async function fetchYouTubeVideos() {
         console.error('Error fetching YouTube videos:', error);
         return [];
     }
+}
+
+function convertToUnixTimestamp(dateString) {
+  try {
+      const date = new Date(dateString);
+      if (isNaN(date.getTime())) {
+        console.log(`Invalid date in blog: ${dateString}`);
+        return '';
+      }
+      return Math.floor(date.getTime() / 1000);
+  } catch (error) {
+      console.error(error.message);
+      return '';
+  }
 }
 
 fetchYouTubeVideos().then(async (videos) => {


### PR DESCRIPTION
To sort results by date, Algolia requires Unix date fields.

Related to https://github.com/redpanda-data/documentation-private/issues/2155