### PR TITLE
ga 24.1

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -27,6 +27,11 @@ to = "/beta"
 status = 301
 
 [[redirects]]
+from = "/beta/*"
+to = "/current/:splat"
+status = 307
+
+[[redirects]]
 from = "/home"
 to = "/current/home"
 status = 301
@@ -224,4 +229,9 @@ status = 301
 [[redirects]]
 from = "/current/develop/guide-nodejs/"
 to = "/redpanda-labs/"
+status = 301
+
+[[redirects]]
+from = "/23.1/*"
+to = "/current/:splat"
 status = 301


### PR DESCRIPTION
EOL 23.1

Add temporary beta redirect from all beta URLs to current version

Should only be merged on April 29th