### PR TITLE
Add null redirect edge functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 .vscode
 /docs/
 .bundle
+# Local Netlify folder
+.netlify

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,10 @@
 [build.environment]
 NODE_VERSION = "18"
 
+[dev]
+  publish = "docs/"
+  framework = "#static"
+
 [[plugins]]
   package = "@netlify/plugin-lighthouse"
 

--- a/netlify/edge-functions/redirect-null.js
+++ b/netlify/edge-functions/redirect-null.js
@@ -1,8 +1,10 @@
 export default async (request, context) => {
   const url = new URL(request.url);
-  if (url.pathname.endsWith('/null') || url.pathname.endsWith('/null/')) {
+  const pathname = url.pathname;
+
+  if (pathname.endsWith('/null') || pathname.endsWith('/null/')) {
     // Remove the "/null" part from the URL
-    let newPathname = url.pathname.replace(/\/null\/?$/, '/');
+    let newPathname = pathname.replace(/\/null\/?$/, '/');
 
     // Ensure the URL ends with a "/" for local tests
     if (!newPathname.endsWith('/')) {

--- a/netlify/edge-functions/redirect-null.js
+++ b/netlify/edge-functions/redirect-null.js
@@ -1,0 +1,22 @@
+export default async (request, context) => {
+  const url = new URL(request.url);
+  if (url.pathname.endsWith('/null') || url.pathname.endsWith('/null/')) {
+    // Remove the "/null" part from the URL
+    let newPathname = url.pathname.replace(/\/null\/?$/, '/');
+
+    // Ensure the URL ends with a "/" for local tests
+    if (!newPathname.endsWith('/')) {
+      newPathname += '/';
+    }
+
+    // Construct the new URL without "/null"
+    const newUrl = `${url.origin}${newPathname}${url.search}`;
+
+    return Response.redirect(newUrl, 301);
+  }
+
+  return context.next();
+};
+
+// This configures the Edge Function to trigger on paths ending with "/null"
+export const config = { path: "*/null" };


### PR DESCRIPTION
A large percentage of our 404s are for `/null` paths. These are likely being autogenerated from AI bots or other systems. 

This PR introduces a Netlify Edge Function designed to intercept any requests to URLs ending in `/null`, remove the `/null` segment, and redirect users to the correct path. This proactive approach ensures that users are redirected to the intended content without encountering a 404 error.

For example:

`http://localhost:8888/current/home/null` will open `http://localhost:8888/current/home/`

Test: https://deploy-preview-73--redpanda-documentation.netlify.app/current/develop/kafka-clients/null

## Why not regular redirects?

From the [Netlify docs](https://docs.netlify.com/routing/redirects/redirect-options/#splats):

> It’s not possible to use an asterisk as a wildcard in the middle of a path, for example /jobs/*.html. You can only use asterisks at the end of the path segment, such as /jobs/*.

This limitation on regular redirects means we can't capture the path before `/null` and redirect the user to the correct location. We'd need to redirect all `/null` paths to a single page which isn't a good user experience.