### PR TITLE
add general redirect for a redpanda connector

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -264,6 +264,24 @@ status = 301
 # =========Cloud redirects========
 
 [[redirects]]
+from = "/*/kafka_migrator"
+to = "/:splat/redpanda_migrator"
+status = 301
+force = true
+
+[[redirects]]
+from = "/*/kafka_migrator_bundle"
+to = "/:splat/redpanda_migrator_bundle"
+status = 301
+force = true
+
+[[redirects]]
+from = "/*/kafka_migrator_offsets"
+to = "/:splat/redpanda_migrator_offsets"
+status = 301
+force = true
+
+[[redirects]]
 from = "/current/reference/rpk/rpk-cloud/*"
 to = "/redpanda-cloud/reference/rpk/rpk-cloud/:splat"
 status = 301


### PR DESCRIPTION
## Description
Auxiliary redirects to help the rename of https://github.com/redpanda-data/cloud-docs/pull/79 and https://github.com/redpanda-data/rp-connect-docs/pull/62

## Test links

### Redpanda Cloud
https://deploy-preview-81--redpanda-documentation.netlify.app/redpanda-cloud/develop/connect/components/inputs/kafka_migrator

https://deploy-preview-81--redpanda-documentation.netlify.app/redpanda-cloud/develop/connect/cookbooks/kafka_migrator/

https://deploy-preview-81--redpanda-documentation.netlify.app/redpanda-cloud/develop/connect/components/outputs/kafka_migrator/

#### Bundle 
https://deploy-preview-81--redpanda-documentation.netlify.app/redpanda-cloud/develop/connect/components/inputs/kafka_migrator_bundle/
https://deploy-preview-81--redpanda-documentation.netlify.app/redpanda-cloud/develop/connect/components/outputs/kafka_migrator_bundle/

### Redpanda Connect
https://deploy-preview-81--redpanda-documentation.netlify.app/redpanda-connect/components/inputs/kafka_migrator/

https://deploy-preview-81--redpanda-documentation.netlify.app/redpanda-connect/components/outputs/kafka_migrator/

https://deploy-preview-81--redpanda-documentation.netlify.app/redpanda-connect/cookbooks/kafka_migrator/

Note that the redirect links will 404 until both content PRs are merged.

