### PR TITLE
Fix indexer for APIs

### DIFF
--- a/scripts/index-api/index-api.js
+++ b/scripts/index-api/index-api.js
@@ -60,14 +60,14 @@ async function indexUrlsInAlgolia(urls) {
       const { pathname } = new URL(url);
       return {
         objectID: pathname,
-        product: "Redpanda",
+        product: "Self-Managed",
         version: data.latestVersion,
         title: data.h1,
         titles: data.titles,
         intro: data.intro,
         unixTimestamp: unixTimestamp,
         type: 'Doc',
-        _tags: [`Redpanda v${data.latestVersion}`]
+        _tags: [`Self-Managed v${data.latestVersion}`]
       };
     } catch (error) {
       console.error(`Error processing URL ${url}:`, error);


### PR DESCRIPTION
We updated the product name and tags to use Self-Managed. However, the API docs are still being indexed under 'Redpanda' leading to API reference docs not showing in the search by default. This PR fixes that.