### PR TITLE
Configure info logs for production builds

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -17,6 +17,9 @@ urls:
   latest_version_segment_strategy: redirect:to
 output:
   clean: true
+runtime:
+  log:
+    level: info
 content:
   sources:
   - url: .


### PR DESCRIPTION
In production, it's useful to see operational messages to check that things are progressing normally. At the moment, we only see warnings.