### PR TITLE
Add bloblang samples extension

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -50,6 +50,7 @@ asciidoc:
 antora:
   extensions:
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-rp-connect-info'
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/collect-bloblang-samples'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-rp-connect-categories'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/modify-redirects'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/algolia-indexer/index'

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -42,6 +42,7 @@ asciidoc:
 antora:
   extensions:
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-rp-connect-categories'
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/collect-bloblang-samples'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/add-pages-to-root'
     files: ['home:ROOT:attachment$llms.txt']
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-rp-connect-info'

--- a/package-lock.json
+++ b/package-lock.json
@@ -739,9 +739,9 @@
       }
     },
     "node_modules/@redpanda-data/docs-extensions-and-macros": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-3.9.1.tgz",
-      "integrity": "sha512-qEs/4KDsFv+P8VZSD41P5VS9oeYtH8MOKJwu6OIVypzBpbBUg6f1MbqaLoy9F8Halh/CIEbwZwpCe72rDijXcg==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-3.10.0.tgz",
+      "integrity": "sha512-H50KCLTBg+qiZdD+k+PHv1m6BDJPAjBLOAdXZBt36oGZucfwCEqwW/6pUVxbbjuHmvfL1MTfDPgqfZRLJpNpRQ==",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/preview-antora-playbook.yml
+++ b/preview-antora-playbook.yml
@@ -46,6 +46,7 @@ asciidoc:
 antora:
   extensions:
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-rp-connect-categories'
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/collect-bloblang-samples'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-rp-connect-info'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/modify-redirects'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/unpublish-pages'


### PR DESCRIPTION
Adds the [required extension](https://github.com/redpanda-data/docs-extensions-and-macros/pull/85) that pulls example mappings into the Bloblang playground.