### PR TITLE
DOC-796 Prepare branch for 24.3 GA

### DIFF
--- a/.github/workflows/index-masterclasses.yaml
+++ b/.github/workflows/index-masterclasses.yaml
@@ -37,13 +37,12 @@ jobs:
         env:
           ALGOLIA_INDEX_NAME: redpanda
           GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
-      - name: Create pull request
-        uses: peter-evans/create-pull-request@v6
-        with:
-          commit-message: "auto-docs: Update Instruqt records"
-          token: ${{ env.ACTIONS_BOT_TOKEN }}
-          branch: update-instruqt-records
-          title: "auto-docs: Update Instruqt records"
-          body: "Updates the Instruqt courses that are made available to docs for purposes such as automated cross-linking."
-          labels: auto-docs
-          reviewers: JakeSCahill, Deflaimun
+      - name: Commit changes
+        run: |
+          git config --global user.name "vbotbuildovich"
+          git config --global user.email "vbotbuildovich@users.noreply.github.com"
+          git add home/modules/ROOT/attachments/instruqt-labs.json
+          git commit -m "auto-docs: Update Instruqt records"
+          git push origin main
+        env:
+          ACCESS_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -26,7 +26,7 @@ content:
     branches: HEAD
     start_paths: [home]
   - url: https://github.com/redpanda-data/docs
-    branches: [main, v/*, api, shared, 'site-search', '!v-end-of-life/*',v-WIP/24.3]
+    branches: [main, v/*, api, shared, 'site-search', '!v-end-of-life/*']
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -18,7 +18,7 @@ content:
     branches: HEAD
     start_paths: [home]
   - url: https://github.com/redpanda-data/docs
-    branches: [main, v/*, api, shared, 'site-search', '!v-end-of-life/*',v-WIP/24.3]
+    branches: [main, v/*, api, shared, 'site-search', '!v-end-of-life/*']
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']

--- a/netlify.toml
+++ b/netlify.toml
@@ -32,15 +32,10 @@ NODE_VERSION = "18"
 # NOTE the following redirects get appended to the redirects defined in the _redirects file
 
 # ========Beta redirects==========
-#[[redirects]]
-#from = "/docs/beta/*"
-#to = "/beta"
-#status = 301
-
-#[[redirects]]
-#from = "/beta/*"
-#to = "/current/:splat"
-#status = 307
+[[redirects]]
+from = "/beta/*"
+to = "/current/:splat"
+status = 307
 
 # ===========Docusaurus to Antora migration redirects============
 [[redirects]]
@@ -139,6 +134,12 @@ to = "/current/:splat"
 status = 301
 
 # ================End of life versions===================
+
+[[redirects]]
+from = "/23.2/*"
+to = "/current/:splat"
+status = 301
+
 [[redirects]]
 from = "/23.1/*"
 to = "/current/:splat"

--- a/preview-antora-playbook.yml
+++ b/preview-antora-playbook.yml
@@ -22,7 +22,7 @@ content:
     branches: HEAD
     start_paths: [home]
   - url: https://github.com/redpanda-data/docs
-    branches: [main, v/*, api, shared, 'site-search', '!v-end-of-life/*',v-WIP/24.3]
+    branches: [main, v/*, api, shared, 'site-search', '!v-end-of-life/*']
   - url: https://github.com/redpanda-data/redpanda-labs
     branches: main
     start_paths: [docs,'*/docs']


### PR DESCRIPTION
In this release, 23.2 reaches its end of life and is removed. We will rename that branch to `v-end-of-life/23.2`.