### PR TITLE
DOC-814 Add redirect for pg_stream page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -283,6 +283,12 @@ status = 301
 force = true
 
 [[redirects]]
+from = "/*/pg_stream"
+to = "/:splat/postgres_cdc"
+status = 301
+force = true
+
+[[redirects]]
 from = "/current/reference/rpk/rpk-cloud/*"
 to = "/redpanda-cloud/reference/rpk/rpk-cloud/:splat"
 status = 301


### PR DESCRIPTION
Add redirect from pg_stream page to postgres_cdc for Cloud docs.

Review date: December 5th