### PR TITLE
DOC-721 Add generate-index-data extension and redirects for old docker index page

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -56,7 +56,6 @@ antora:
       sets:
         docker_labs:
           component: redpanda-labs
-          family: page
           filter: docker-compose
           env_type: Docker
           attribute_name: docker-labs-index

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -51,6 +51,15 @@ antora:
   extensions:
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-rp-connect-info'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/collect-bloblang-samples'
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-index-data'
+    data:
+      sets:
+        docker_labs:
+          component: redpanda-labs
+          family: page
+          filter: docker-compose
+          env_type: Docker
+          attribute_name: docker-labs-index
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-rp-connect-categories'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/modify-redirects'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/algolia-indexer/index'

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -48,7 +48,6 @@ antora:
       sets:
         docker_labs:
           component: redpanda-labs
-          family: page
           filter: docker-compose
           env_type: Docker
           attribute_name: docker-labs-index

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -43,6 +43,15 @@ antora:
   extensions:
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-rp-connect-categories'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/collect-bloblang-samples'
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-index-data'
+    data:
+      sets:
+        docker_labs:
+          component: redpanda-labs
+          family: page
+          filter: docker-compose
+          env_type: Docker
+          attribute_name: docker-labs-index
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/add-pages-to-root'
     files: ['home:ROOT:attachment$llms.txt']
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-rp-connect-info'

--- a/netlify.toml
+++ b/netlify.toml
@@ -165,11 +165,29 @@ from = "/21.11/*"
 to = "/current/:splat"
 status = 301
 
-# =========Bulk redirects from different components========
+# ========= Docker example redirects =====================
+
 [[redirects]]
 from = "/current/reference/docker-compose/"
-to = "/redpanda-labs/"
+to = "/current/get-started/docker-compose-labs/"
 status = 301
+
+[[redirects]]
+from = "/current/console/reference/docker-compose/"
+to = "/current/get-started/docker-compose-labs/"
+status = 301
+
+[[redirects]]
+from = "/current/reference/console/docker-compose/"
+to = "/current/get-started/docker-compose-labs/"
+status = 301
+
+[[redirects]]
+from = "/23.2/reference/docker-compose/"
+to = "/current/get-started/docker-compose-labs/"
+status = 301
+
+# =========Bulk redirects from different components========
 
 [[redirects]]
 from = "/current/develop/chat-room/"
@@ -198,16 +216,6 @@ status = 301
 
 [[redirects]]
 from = "/current/develop/code-samples/"
-to = "/redpanda-labs/"
-status = 301
-
-[[redirects]]
-from = "/current/console/reference/docker-compose/"
-to = "/redpanda-labs/"
-status = 301
-
-[[redirects]]
-from = "/current/reference/console/docker-compose/"
 to = "/redpanda-labs/"
 status = 301
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -739,9 +739,9 @@
       }
     },
     "node_modules/@redpanda-data/docs-extensions-and-macros": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-3.10.0.tgz",
-      "integrity": "sha512-H50KCLTBg+qiZdD+k+PHv1m6BDJPAjBLOAdXZBt36oGZucfwCEqwW/6pUVxbbjuHmvfL1MTfDPgqfZRLJpNpRQ==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@redpanda-data/docs-extensions-and-macros/-/docs-extensions-and-macros-3.11.0.tgz",
+      "integrity": "sha512-yULgu5bZoubLxHhigFq18euSIgxxv6fbe8LSgMx0KBqxU+UhpJKyk+7JbRAshvZdSNRA5o7Y6+i5zjpQwlTpMg==",
       "license": "ISC",
       "dependencies": {
         "@asciidoctor/tabs": "^1.0.0-beta.6",

--- a/preview-antora-playbook.yml
+++ b/preview-antora-playbook.yml
@@ -53,7 +53,6 @@ antora:
       sets:
         docker_labs:
           component: redpanda-labs
-          family: page
           filter: docker-compose
           env_type: Docker
           attribute_name: docker-labs-index

--- a/preview-antora-playbook.yml
+++ b/preview-antora-playbook.yml
@@ -48,6 +48,15 @@ antora:
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-rp-connect-categories'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/collect-bloblang-samples'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-rp-connect-info'
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-index-data'
+    data:
+      sets:
+        docker_labs:
+          component: redpanda-labs
+          family: page
+          filter: docker-compose
+          env_type: Docker
+          attribute_name: docker-labs-index
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/modify-redirects'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/unpublish-pages'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/unlisted-pages'


### PR DESCRIPTION
https://docs.redpanda.com/23.2/reference/docker-compose/ was one of our most popular pages, according to Google. It was a list of all Docker Compose examples. Now that 23.2 has reached its end of life, this PR adds redirects to a new autogenerated index page of all Docker Compose examples so that users can still reach that content.

Depends on:

- https://github.com/redpanda-data/docs-extensions-and-macros/pull/87
- https://github.com/redpanda-data/docs-ui/pull/236