### PR TITLE
Display new EoL banners when component versions have a `page-release-date` attribute

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -65,6 +65,14 @@ antora:
     excludes: ['.thumbs','script', '.page-versions','.feedback-section','.banner-container']
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/add-pages-to-root'
     files: ['home:ROOT:attachment$llms.txt']
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/end-of-life'
+    data:
+      eol_settings:
+        - component: 'ROOT'
+          supported_months: 12
+          warning_weeks: 13
+          eol_doc: https://support.redpanda.com/hc/en-us/articles/20617574366743-Redpanda-Supported-Versions
+          upgrade_doc: ROOT:upgrade:index.adoc
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/unpublish-pages'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/unlisted-pages'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/add-global-attributes'

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -65,7 +65,7 @@ antora:
     excludes: ['.thumbs','script', '.page-versions','.feedback-section','.banner-container']
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/add-pages-to-root'
     files: ['home:ROOT:attachment$llms.txt']
-  - require: '@redpanda-data/docs-extensions-and-macros/extensions/end-of-life'
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/compute-end-of-life'
     data:
       eol_settings:
         - component: 'ROOT'

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -53,6 +53,14 @@ antora:
           attribute_name: docker-labs-index
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/add-pages-to-root'
     files: ['home:ROOT:attachment$llms.txt']
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/end-of-life'
+    data:
+      eol_settings:
+        - component: 'ROOT'
+          supported_months: 12
+          warning_weeks: 13
+          eol_doc: https://support.redpanda.com/hc/en-us/articles/20617574366743-Redpanda-Supported-Versions
+          upgrade_doc: ROOT:upgrade:index.adoc
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/generate-rp-connect-info'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/modify-redirects'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/unpublish-pages'

--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -53,7 +53,7 @@ antora:
           attribute_name: docker-labs-index
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/add-pages-to-root'
     files: ['home:ROOT:attachment$llms.txt']
-  - require: '@redpanda-data/docs-extensions-and-macros/extensions/end-of-life'
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/compute-end-of-life'
     data:
       eol_settings:
         - component: 'ROOT'

--- a/preview-antora-playbook.yml
+++ b/preview-antora-playbook.yml
@@ -56,7 +56,7 @@ antora:
           filter: docker-compose
           env_type: Docker
           attribute_name: docker-labs-index
-  - require: '@redpanda-data/docs-extensions-and-macros/extensions/end-of-life'
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/compute-end-of-life'
     data:
       eol_settings:
         - component: 'ROOT'

--- a/preview-antora-playbook.yml
+++ b/preview-antora-playbook.yml
@@ -56,6 +56,14 @@ antora:
           filter: docker-compose
           env_type: Docker
           attribute_name: docker-labs-index
+  - require: '@redpanda-data/docs-extensions-and-macros/extensions/end-of-life'
+    data:
+      eol_settings:
+        - component: 'ROOT'
+          supported_months: 12
+          warning_weeks: 13
+          eol_doc: https://support.redpanda.com/hc/en-us/articles/20617574366743-Redpanda-Supported-Versions
+          upgrade_doc: ROOT:upgrade:index.adoc
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/modify-redirects'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/unpublish-pages'
   - require: '@redpanda-data/docs-extensions-and-macros/extensions/unlisted-pages'


### PR DESCRIPTION
- Upgrades our extensions and macros package to 4.2.0.
- Configures the `compute-end-of-life` extension to support EoL banners for Self-Managed (ROOT) docs.

Relies on:

- https://github.com/redpanda-data/docs/pull/949
- https://github.com/redpanda-data/docs/pull/950
- https://github.com/redpanda-data/docs/pull/948
- https://github.com/redpanda-data/docs/pull/947