### PR TITLE
Redirect docs.vectorized.io to docs.redpanda.com

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -31,6 +31,12 @@ NODE_VERSION = "18"
 
 # NOTE the following redirects get appended to the redirects defined in the _redirects file
 
+[[redirects]]
+from = "https://docs.vectorized.io/*"
+to = "https://docs.redpanda.com/:splat"
+status = 301
+force = true
+
 # ========Beta redirects==========
 #[[redirects]]
 #from = "/beta/*"


### PR DESCRIPTION
We have a CNAME record configured for our Netlify account, which serves our docs on both domains.

By keeping the CNAME but adding a 301 redirect, we get these benefits:

- Prevents duplicate content issues by consolidating search rankings under docs.redpanda.com.
- Google treats a 301 redirect as a permanent move and passes SEO value from docs.vectorized.io to docs.redpanda.com.
- Users will always land on docs.redpanda.com, reinforcing the primary domain name.
- No risk of users getting confused about which domain to use or bookmark.
- With a redirect, all traffic flows to docs.redpanda.com, keeping data clean in tools like Google Analytics.
- If we ever retire docs.vectorized.io, users will already be used to docs.redpanda.com.