### PR TITLE
Allow the indexer to work in CI/CD pipeline

### DIFF
--- a/scripts/index-api/index-api.js
+++ b/scripts/index-api/index-api.js
@@ -24,7 +24,10 @@ const client = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_ADMIN_API_KEY);
 const index = client.initIndex(ALGOLIA_INDEX_NAME);
 
 async function scrapeAndIndex() {
-  const browser = await puppeteer.launch({ headless: 'new' });
+  const browser = await puppeteer.launch({
+  headless: 'new',
+  args: ['--no-sandbox', '--disable-setuid-sandbox']
+  });
   const allRecords = [];
 
   for (const path of DOC_PATHS) {


### PR DESCRIPTION
This pull request makes a minor update to the Puppeteer browser launch configuration to improve compatibility and security when running in certain environments.

- Puppeteer Launch Configuration:
  * Updated the `puppeteer.launch` call in `index-api.js` to include the `--no-sandbox` and `--disable-setuid-sandbox` arguments, which are commonly required for running headless browsers in CI/CD pipelines or restricted environments.