### PR TITLE
Fix indexer actions

### DIFF
--- a/.github/workflows/index-api.yaml
+++ b/.github/workflows/index-api.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install dependencies
         run: cd scripts/index-api && npm install
       - name: Run indexing script

--- a/.github/workflows/index-blogs.yaml
+++ b/.github/workflows/index-blogs.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install dependencies
         run: cd scripts/index-blogs && npm install
       - name: Run indexing script

--- a/.github/workflows/index-masterclasses.yaml
+++ b/.github/workflows/index-masterclasses.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install dependencies
         run: cd scripts/index-masterclasses && npm install
       - name: Run indexing script
@@ -37,12 +37,13 @@ jobs:
         env:
           ALGOLIA_INDEX_NAME: redpanda
           GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
-      - name: Commit changes
-        run: |
-          git config --global user.name "vbotbuildovich"
-          git config --global user.email "vbotbuildovich@users.noreply.github.com"
-          git add home/modules/ROOT/attachments/instruqt-labs.json
-          git commit -m "auto-docs: Update Instruqt records"
-          git push origin main
-        env:
-          ACCESS_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ env.ACTIONS_BOT_TOKEN }}
+          base: main
+          branch: auto-docs/update-masterclass-index
+          title: 'auto-docs: Update Masterclass docs'
+          commit-message: 'docs: Update Masterclass docs'
+          body: Update the Masterclass docs to reflect the latest courses and labs available on Instruqt.
+          labels: auto-docs

--- a/.github/workflows/index-youtube.yaml
+++ b/.github/workflows/index-youtube.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
       - name: Install dependencies
         run: cd scripts/index-youtube && npm install
       - name: Run indexing script

--- a/scripts/index-blogs/index-blogs.js
+++ b/scripts/index-blogs/index-blogs.js
@@ -33,7 +33,10 @@ async function fetchSitemapUrls(sitemapUrl) {
 }
 
 async function indexUrlsInAlgolia(urls) {
-  const browser = await puppeteer.launch({headless: "new"});
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-setuid-sandbox']
+  });
   const records = await Promise.all(urls.map(async (url) => {
     if (!url.includes('/blog/')) return null
     const page = await browser.newPage();


### PR DESCRIPTION
The Instruqt action no longer has permission to commit directly to the repo, so instead, we open a PR.

The blogs indexer was getting errors related to the `pupeteer` instance. I updated it to use the same strategy as the API indexer:

```
Blog indexing failed: Error: Failed to launch the browser process!
[2370:2370:0828/155930.716641:FATAL:zygote_host_impl_linux.cc(127)] No usable sandbox! 
```
