### PR TITLE
DOC-2090 Fix Claude Desktop MCP connection configuration

### DIFF
--- a/home/modules/ROOT/pages/mcp-setup.adoc
+++ b/home/modules/ROOT/pages/mcp-setup.adoc
@@ -125,7 +125,7 @@ This configuration uses the `mcp-remote` bridge to connect to Redpanda's remote 
 
 Restart Claude Desktop for changes to take effect.
 
-IMPORTANT: On some platforms, Claude Desktop cannot connect to remote servers configured via `claude_desktop_config.json`. If this method doesn't work, use the Connectors interface instead (available with Pro, Max, Team, or Enterprise plans).
+IMPORTANT: On some platforms, Claude Desktop cannot connect to remote servers configured using `claude_desktop_config.json`. If this method doesn't work, use the Connectors interface instead (available with Pro, Max, Team, or Enterprise plans).
 
 For more details, see the https://support.anthropic.com/en/articles/9487310-desktop-app[Claude Desktop documentation^].
 --

--- a/home/modules/ROOT/pages/mcp-setup.adoc
+++ b/home/modules/ROOT/pages/mcp-setup.adoc
@@ -84,7 +84,21 @@ For more information, see the https://platform.openai.com/docs/guides/developer-
 Claude Desktop::
 +
 --
-To add Redpanda's MCP server to Claude Desktop:
+There are two methods to connect Claude Desktop to Redpanda's MCP server:
+
+**Method 1: Using Connectors (Recommended for Linux)**
+
+This method works across all platforms and is required for Linux users:
+
+. Open Claude Desktop
+. Navigate to **Settings** > **Connectors**
+. Click **Add custom connector**
+. Enter the URL: `https://docs.redpanda.com/mcp`
+. Follow any authentication prompts if required
+
+**Method 2: Using Configuration File (macOS and Windows)**
+
+Edit the Claude Desktop configuration file:
 
 **On macOS:**
 `~/Library/Application Support/Claude/claude_desktop_config.json`
@@ -99,14 +113,18 @@ Add this configuration:
 {
   "mcpServers": {
     "redpanda": {
-      "type": "http",
-      "url": "https://docs.redpanda.com/mcp"
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://docs.redpanda.com/mcp"]
     }
   }
 }
 ----
 
+This uses the `mcp-remote` bridge to connect to Redpanda's remote MCP server. Claude Desktop currently only supports `stdio` and `sse` transports, so `mcp-remote` converts the HTTP endpoint to a format Claude Desktop can use.
+
 Restart Claude Desktop for changes to take effect.
+
+NOTE: On Linux, remote MCP servers through the configuration file may not be supported. Use the Connectors interface instead.
 
 For more details, see the https://support.anthropic.com/en/articles/9487310-desktop-app[Claude Desktop documentation^].
 --

--- a/home/modules/ROOT/pages/mcp-setup.adoc
+++ b/home/modules/ROOT/pages/mcp-setup.adoc
@@ -17,16 +17,16 @@ Run the following command to add the Redpanda MCP server to Claude Code:
 
 [source,bash]
 ----
-claude mcp add --transport stdio --scope user redpanda -- \
+claude mcp add --scope user redpanda -- \
   npx -y mcp-remote https://docs.redpanda.com/mcp
 ----
 
 This command:
 
-* Adds the MCP server with the name `redpanda`
-* Uses the `mcp-remote` bridge to connect to the HTTP endpoint
-* Configures it for your user account (stores in `~/.claude.json`)
-* Works on all platforms (macOS, Linux, Windows)
+* Adds the MCP server with the name `redpanda`.
+* Uses the `mcp-remote` bridge to connect to the HTTP endpoint.
+* Configures it for your user account (stores in `~/.claude.json`).
+* Works on all platforms (macOS, Linux, Windows).
 
 To verify the installation:
 
@@ -35,7 +35,7 @@ To verify the installation:
 claude mcp list
 ----
 
-For more information about Claude Code, see the https://docs.anthropic.com/en/docs/agents-and-tool-use/model-context-protocol[Claude Code documentation^].
+For more information about Claude Code, see the https://code.claude.com/docs/en/mcp[Claude Code documentation^].
 --
 Cursor::
 +
@@ -127,7 +127,7 @@ NOTE: When using Connectors, Claude connects to your remote MCP server from Anth
 
 *Method 2: Using Configuration File*
 
-This method works for all plans, including free tier.
+This method works for all plans, including Free plan.
 
 Edit the Claude Desktop configuration file for your platform:
 
@@ -152,7 +152,7 @@ This configuration uses the `mcp-remote` bridge to connect to Redpanda's remote 
 
 Restart Claude Desktop for changes to take effect.
 
-IMPORTANT: On some platforms, Claude Desktop cannot connect to remote servers configured using `claude_desktop_config.json`. If this method doesn't work, use the Connectors interface instead (available with Pro, Max, Team, or Enterprise plans).
+IMPORTANT: On Linux, Claude Desktop cannot connect to remote servers configured using `claude_desktop_config.json`. If this method doesn't work, use the Connectors interface instead (available with Pro, Max, Team, or Enterprise plans).
 
 For more details, see the https://support.anthropic.com/en/articles/9487310-desktop-app[Claude Desktop documentation^].
 --
@@ -237,7 +237,7 @@ RateLimit-Reset: <timestamp>
 
 === Configuration issues
 
-* Ensure `"type": "http"` is specified in your configuration for HTTP-based MCP servers.
+* For Cursor and VS Code, ensure `"type": "http"` is specified in your configuration. For Claude Desktop, use the `mcp-remote` bridge shown in the Set up section -- Claude Desktop does not support `"type": "http"`.
 * Some MCP clients may have issues with SSE streaming. If you experience connection problems, verify that your client supports HTTP-based MCP servers with Server-Sent Events (SSE).
 * Check that your client's Accept headers include both `application/json` and `text/event-stream`.
 

--- a/home/modules/ROOT/pages/mcp-setup.adoc
+++ b/home/modules/ROOT/pages/mcp-setup.adoc
@@ -1,7 +1,7 @@
 = MCP Server for Redpanda Documentation
-:description: Learn how to connect to the Redpanda documentation MCP server in Cursor, VS Code, ChatGPT, and other AI tools.
+:description: Learn how to connect to the Redpanda documentation MCP server in Claude Code, Cursor, VS Code, ChatGPT, and other AI tools.
 
-Redpanda provides a remote link:https://modelcontextprotocol.io[Model Context Protocol (MCP) server^] that lets you access authoritative Redpanda documentation directly from your IDE or AI tool, such as Cursor, VS Code, ChatGPT, or Claude.
+Redpanda provides a remote link:https://modelcontextprotocol.io[Model Context Protocol (MCP) server^] that lets you access authoritative Redpanda documentation directly from your IDE or AI tool, such as Claude Code, Cursor, VS Code, ChatGPT, or Claude Desktop.
 
 The MCP server is hosted at: `\https://docs.redpanda.com/mcp`.
 You can add this endpoint to any AI agent that supports MCP.
@@ -10,6 +10,33 @@ You can add this endpoint to any AI agent that supports MCP.
 
 [tabs]
 ====
+Claude Code::
++
+--
+Run the following command to add the Redpanda MCP server to Claude Code:
+
+[source,bash]
+----
+claude mcp add --transport stdio --scope user redpanda -- \
+  npx -y mcp-remote https://docs.redpanda.com/mcp
+----
+
+This command:
+
+* Adds the MCP server with the name `redpanda`
+* Uses the `mcp-remote` bridge to connect to the HTTP endpoint
+* Configures it for your user account (stores in `~/.claude.json`)
+* Works on all platforms (macOS, Linux, Windows)
+
+To verify the installation:
+
+[source,bash]
+----
+claude mcp list
+----
+
+For more information about Claude Code, see the https://docs.anthropic.com/en/docs/agents-and-tool-use/model-context-protocol[Claude Code documentation^].
+--
 Cursor::
 +
 --

--- a/home/modules/ROOT/pages/mcp-setup.adoc
+++ b/home/modules/ROOT/pages/mcp-setup.adoc
@@ -84,31 +84,30 @@ For more information, see the https://platform.openai.com/docs/guides/developer-
 Claude Desktop::
 +
 --
-There are two methods to connect Claude Desktop to Redpanda's MCP server:
+Connect Claude Desktop to Redpanda's MCP server using one of two methods:
 
-**Method 1: Using Connectors**
+*Method 1: Using Connectors*
 
-This method is available for Pro, Max, Team, and Enterprise plans. It works across all platforms (macOS, Windows, Linux):
+This method is available for Pro, Max, Team, or Enterprise plans and works across all platforms (macOS, Windows, Linux):
 
-. Open Claude Desktop
-. Navigate to **Settings** > **Connectors**
-. Click **Add custom connector**
+. Open Claude Desktop.
+. Navigate to Settings > Connectors.
+. Click **Add custom connector**.
 . Enter the URL: `https://docs.redpanda.com/mcp`
-. Follow any authentication prompts if required
+. Follow any authentication prompts if required.
 
 NOTE: When using Connectors, Claude connects to your remote MCP server from Anthropic's cloud infrastructure.
 
-**Method 2: Using Configuration File (Free Tier and All Plans)**
+*Method 2: Using Configuration File*
 
-Edit the Claude Desktop configuration file:
+This method works for all plans, including free tier.
 
-**On macOS:**
-`~/Library/Application Support/Claude/claude_desktop_config.json`
+Edit the Claude Desktop configuration file for your platform:
 
-**On Windows:**
-`%APPDATA%\Claude\claude_desktop_config.json`
+* *macOS*: `~/Library/Application Support/Claude/claude_desktop_config.json`
+* *Windows*: `%APPDATA%\Claude\claude_desktop_config.json`
 
-Add this configuration:
+Add the following configuration to your `claude_desktop_config.json` file:
 
 [source,json]
 ----
@@ -122,11 +121,11 @@ Add this configuration:
 }
 ----
 
-This uses the `mcp-remote` bridge to connect to Redpanda's remote MCP server. Claude Desktop currently only supports `stdio` and `sse` transports in the config file, so `mcp-remote` converts the HTTP endpoint to a format Claude Desktop can use.
+This configuration uses the `mcp-remote` bridge to connect to Redpanda's remote MCP server. Claude Desktop supports only `stdio` and `sse` transports, so `mcp-remote` converts the HTTP endpoint to a compatible format.
 
 Restart Claude Desktop for changes to take effect.
 
-IMPORTANT: Claude Desktop does not connect to remote servers configured directly via `claude_desktop_config.json` on some platforms. If this method doesn't work for you, use the Connectors interface instead (requires Pro/Max/Team/Enterprise plan).
+IMPORTANT: On some platforms, Claude Desktop cannot connect to remote servers configured via `claude_desktop_config.json`. If this method doesn't work, use the Connectors interface instead (available with Pro, Max, Team, or Enterprise plans).
 
 For more details, see the https://support.anthropic.com/en/articles/9487310-desktop-app[Claude Desktop documentation^].
 --

--- a/home/modules/ROOT/pages/mcp-setup.adoc
+++ b/home/modules/ROOT/pages/mcp-setup.adoc
@@ -86,9 +86,9 @@ Claude Desktop::
 --
 There are two methods to connect Claude Desktop to Redpanda's MCP server:
 
-**Method 1: Using Connectors (Recommended for Linux)**
+**Method 1: Using Connectors**
 
-This method works across all platforms and is required for Linux users:
+This method is available for Pro, Max, Team, and Enterprise plans. It works across all platforms (macOS, Windows, Linux):
 
 . Open Claude Desktop
 . Navigate to **Settings** > **Connectors**
@@ -96,7 +96,9 @@ This method works across all platforms and is required for Linux users:
 . Enter the URL: `https://docs.redpanda.com/mcp`
 . Follow any authentication prompts if required
 
-**Method 2: Using Configuration File (macOS and Windows)**
+NOTE: When using Connectors, Claude connects to your remote MCP server from Anthropic's cloud infrastructure.
+
+**Method 2: Using Configuration File (Free Tier and All Plans)**
 
 Edit the Claude Desktop configuration file:
 
@@ -120,11 +122,11 @@ Add this configuration:
 }
 ----
 
-This uses the `mcp-remote` bridge to connect to Redpanda's remote MCP server. Claude Desktop currently only supports `stdio` and `sse` transports, so `mcp-remote` converts the HTTP endpoint to a format Claude Desktop can use.
+This uses the `mcp-remote` bridge to connect to Redpanda's remote MCP server. Claude Desktop currently only supports `stdio` and `sse` transports in the config file, so `mcp-remote` converts the HTTP endpoint to a format Claude Desktop can use.
 
 Restart Claude Desktop for changes to take effect.
 
-NOTE: On Linux, remote MCP servers through the configuration file may not be supported. Use the Connectors interface instead.
+IMPORTANT: Claude Desktop does not connect to remote servers configured directly via `claude_desktop_config.json` on some platforms. If this method doesn't work for you, use the Connectors interface instead (requires Pro/Max/Team/Enterprise plan).
 
 For more details, see the https://support.anthropic.com/en/articles/9487310-desktop-app[Claude Desktop documentation^].
 --


### PR DESCRIPTION
## Summary

Fixes https://redpandadata.atlassian.net/browse/DOC-2090

Fixes the Claude Desktop configuration for connecting to the Redpanda documentation MCP server.

The previous configuration used `"type": "http"` which Claude Desktop does not support, causing "invalid MCP server config entries" errors. Claude Desktop only supports `stdio` and `sse` transports.

## Changes

- Added two methods for connecting:
  - **Method 1**: Connectors interface (requires Pro/Max/Team/Enterprise plan)
  - **Method 2**: Configuration file using `mcp-remote` bridge (works for all plans)
- Clarified plan requirements and platform compatibility
- Applied docs team style standards (active voice, reduced bold, improved formatting)
- Replaced 'via' with 'using' per Google style guide

## Testing

Verified that the `mcp-remote` configuration works on macOS as reported by Michele.