### PR TITLE
feat: add do11y edge function proxy for Axiom analytics

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -68,6 +68,11 @@ to = "https://docs.redpanda.com/:splat"
 status = 301
 force = true
 
+# do11y analytics proxy (must be before generic /api/* rule)
+[[edge_functions]]
+path = "/api/do11y"
+function = "do11y-proxy"
+
 [[edge_functions]]
 path = "/api/*"
 function = "proxy-api-docs"

--- a/netlify/edge-functions/do11y-proxy.js
+++ b/netlify/edge-functions/do11y-proxy.js
@@ -1,0 +1,54 @@
+/**
+ * Edge function to proxy do11y analytics requests to Axiom.
+ * Keeps the Axiom API token server-side for security.
+ */
+export default async (request, context) => {
+  // Only allow POST requests
+  if (request.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405 });
+  }
+
+  const AXIOM_TOKEN = Deno.env.get('AXIOM_DO11Y_TOKEN');
+  const AXIOM_DATASET = Deno.env.get('AXIOM_DO11Y_DATASET') || 'redpanda-docs-analytics';
+
+  if (!AXIOM_TOKEN) {
+    console.error('AXIOM_DO11Y_TOKEN environment variable not configured');
+    return new Response('Axiom token not configured', { status: 500 });
+  }
+
+  try {
+    const body = await request.json();
+
+    const response = await fetch(
+      `https://api.axiom.co/v1/datasets/${AXIOM_DATASET}/ingest`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${AXIOM_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      }
+    );
+
+    if (!response.ok) {
+      console.error(`Axiom API error: ${response.status} ${response.statusText}`);
+    }
+
+    return new Response(null, {
+      status: response.status,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
+      }
+    });
+  } catch (error) {
+    console.error('do11y proxy error:', error);
+    return new Response('Proxy error', { status: 500 });
+  }
+};
+
+export const config = {
+  path: '/api/do11y',
+};


### PR DESCRIPTION
## Summary
- Add Netlify edge function to proxy do11y analytics requests to Axiom
- Keeps API token server-side for security
- Handles `/api/do11y` endpoint

## Setup Required
After merging, set these environment variables in Netlify:
- `AXIOM_DO11Y_TOKEN` - Axiom API ingest token  
- `AXIOM_DO11Y_DATASET` - Dataset name (defaults to `redpanda-docs-analytics`)

## Related PR
- docs-ui PR with do11y integration: https://github.com/redpanda-data/docs-ui/pull/375

## Test plan
- [ ] Deploy to preview environment
- [ ] Verify `/api/do11y` endpoint responds
- [ ] Verify events are proxied to Axiom
- [ ] Verify token is not exposed in client

🤖 Generated with [Claude Code](https://claude.com/claude-code)