### PR TITLE
Fix Claude Code MCP connection using HTTP transport

### DIFF
--- a/home/modules/ROOT/pages/mcp-setup.adoc
+++ b/home/modules/ROOT/pages/mcp-setup.adoc
@@ -17,14 +17,13 @@ Run the following command to add the Redpanda MCP server to Claude Code:
 
 [source,bash]
 ----
-claude mcp add --scope user redpanda -- \
-  npx -y mcp-remote https://docs.redpanda.com/mcp
+claude mcp add --scope user --transport http redpanda https://docs.redpanda.com/mcp
 ----
 
 This command:
 
 * Adds the MCP server with the name `redpanda`.
-* Uses the `mcp-remote` bridge to connect to the HTTP endpoint.
+* Uses the native HTTP transport to connect directly to the endpoint.
 * Configures it for your user account (stores in `~/.claude.json`).
 * Works on all platforms (macOS, Linux, Windows).
 
@@ -34,6 +33,8 @@ To verify the installation:
 ----
 claude mcp list
 ----
+
+You should see `redpanda: https://docs.redpanda.com/mcp (HTTP) - ✓ Connected` in the output.
 
 For more information about Claude Code, see the https://code.claude.com/docs/en/mcp[Claude Code documentation^].
 --
@@ -237,7 +238,8 @@ RateLimit-Reset: <timestamp>
 
 === Configuration issues
 
-* For Cursor and VS Code, ensure `"type": "http"` is specified in your configuration. For Claude Desktop, use the `mcp-remote` bridge shown in the Set up section -- Claude Desktop does not support `"type": "http"`.
+* For Claude Code, Cursor, and VS Code, use the HTTP transport (`--transport http` or `"type": "http"`). For Claude Desktop, use the `mcp-remote` bridge shown in the Set up section -- Claude Desktop does not support direct HTTP transport.
+* If you previously configured Claude Code using `mcp-remote` and experience connection issues, remove the old configuration and use the HTTP transport method shown above.
 * Some MCP clients may have issues with SSE streaming. If you experience connection problems, verify that your client supports HTTP-based MCP servers with Server-Sent Events (SSE).
 * Check that your client's Accept headers include both `application/json` and `text/event-stream`.
 


### PR DESCRIPTION
## Summary

Fixes the Claude Code MCP server connection issue by using the native HTTP transport instead of mcp-remote.

## Problem

The current documentation instructs users to connect using:
```bash
claude mcp add --scope user redpanda -- npx -y mcp-remote https://docs.redpanda.com/mcp
```

This causes connection failures because `mcp-remote` hangs during OAuth discovery even though the server doesn't require authentication. Users see:
```
redpanda: npx -y mcp-remote https://docs.redpanda.com/mcp - ✗ Failed to connect
```

## Solution

Use Claude Code's native HTTP transport flag instead:
```bash
claude mcp add --scope user --transport http redpanda https://docs.redpanda.com/mcp
```

This connects successfully:
```
redpanda: https://docs.redpanda.com/mcp (HTTP) - ✓ Connected
```

## Changes

- Updated Claude Code setup command to use `--transport http`
- Added expected verification output
- Updated troubleshooting section to recommend HTTP transport for Claude Code, Cursor, and VS Code
- Added migration note for users who previously configured with mcp-remote

## Preview pages

- [MCP Server for Redpanda Documentation](https://deploy-preview-171--redpanda-documentation.netlify.app/home/mcp-setup/) (updated)

## Testing

Tested on macOS with Claude Code:
1. Removed old mcp-remote configuration
2. Added using HTTP transport
3. Verified connection succeeds with `claude mcp list`
4. Confirmed MCP tools are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)